### PR TITLE
INFRASEC-24: Fix underscores in variables and values printed at startup

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -77,7 +77,7 @@ fi
 
 eval_export() {
     to_export="$@"
-    keys=$(for v in $to_export ; do echo $v | awk -F '=' '{print $1}' ; done)
+    keys=$(for v in "$to_export" ; do echo "$v" | awk -F '=' '{print $1}' ; done)
     echo $keys
     eval export $to_export
 }
@@ -103,7 +103,7 @@ if [ $chamber_result != 0 ]; then
 fi
 
 # We want to remove 'export' from the env output and also convert - into _ for env names
-to_secrets=$(echo $chamber_env | sed 's/export //g' | for e in $(cat -) ; do echo $e | awk '{ gsub("-", "_", $1) } 1' FS='=' OFS='='; done)
+to_secrets=$(echo "$chamber_env" | sed 's/export //g' | for e in "$(cat -)" ; do echo "$e" | awk '{ gsub("-", "_", $1) } 1' FS='=' OFS='='; done)
 eval_export $to_secrets
 
 # Perform overrides


### PR DESCRIPTION
### Description
When the value of a secret contains several words with a blank space or a hyphen between them, some of those words are printed in the log at the beginning and also the value might change if it includes a hyphen, because it changes to an underscore.

### Files

[init.sh](https://github.com/signal-ai/signal-secret-service/blob/master/init.sh)

### To Reproduce

1. **VARIABLE1** is stored in the parameter store (its value includes a hyphen):
`chamber write <service_name> VARIABLE1 'VALUE1 VALUE2-VALUE3'`
2. When **init.sh** is executed (e.g. `/init.sh env`), it retrieves:
```
VARIABLE1='VALUE1
VALUE2_VALUE3'
```
instead of:
```
VARIABLE1='VALUE1 VALUE2-VALUE3'
```

### Posible solutions
Add double quotes when invoking a variable containing multiple words.

1. **For the case of the hyphen changing to underscore:** replace line 94 in **init.sh**
from:

```
to_secrets=$(echo $chamber_env | sed 's/export //g' | for e in $(cat -) ; do echo $e | awk '{ gsub("-", "_", $1) } 1' FS='=' OFS='='; done)
```
to:
```
to_secrets=$(echo "$chamber_env" | sed 's/export //g' | for e in "$(cat -)" ; do echo "$e" | awk '{ gsub("-", "_", $1) } 1' FS='=' OFS='='; done)
```

2. **For the values being printed in the log:**
Change line 95 from: `eval_export $to_secrets` to `eval_export "$to_secrets"`
And change function _eval_export_ (line 66) from:
```
eval_export() {
    to_export="$@"
    keys=$(for v in $to_export ; do echo $v | awk -F '=' '{print $1}' ; done)
    echo $keys
    eval export $to_export
}
```
to:
```
eval_export() {
    to_export="$@"
    keys=$(for v in "$to_export" ; do echo "$v" | awk -F '=' '{print $1}' ; done)
    echo $keys
    eval export $to_export
}
```
